### PR TITLE
enable LDAP support

### DIFF
--- a/conf/gitlab.rb
+++ b/conf/gitlab.rb
@@ -1,0 +1,21 @@
+external_url 'GENERATED_EXTERNAL_URL'
+
+gitlab_rails['ldap_enabled'] = true
+gitlab_rails['ldap_servers'] = YAML.load <<-'EOS' # remember to close this block with 'EOS' below
+  main: # 'main' is the GitLab 'provider ID' of this LDAP server
+    label: 'LDAP'
+    host: 'localhost'
+    port: 389
+    uid: 'uid'
+    method: 'plain' # "tls" or "ssl" or "plain"
+    bind_dn: ''
+    password: ''
+    active_directory: false
+    allow_username_or_email_login: false
+    block_auto_created_users: false
+    base: 'ou=users,dc=yunohost,dc=org'
+    user_filter: ''
+EOS
+
+nginx['listen_port'] = PORT
+nginx['listen_https'] = false

--- a/conf/gitlab.rb
+++ b/conf/gitlab.rb
@@ -17,5 +17,7 @@ gitlab_rails['ldap_servers'] = YAML.load <<-'EOS' # remember to close this block
     user_filter: ''
 EOS
 
-nginx['listen_port'] = PORT
+nginx['listen_port'] = PORTNGINX
 nginx['listen_https'] = false
+
+unicorn['port'] = PORTUNICORN

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -1,33 +1,10 @@
 location YNH_WWW_PATH {
 
-  # Path to source
-  alias YNH_WWW_ALIAS ;
+	proxy_pass http://localhost:PORT;
+	proxy_set_header Host $host;
+	proxy_set_header X-Forwarded-Ssl on;
+	proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 
-  # Example PHP configuration (remove if not used)
-  index index.php;
-
-  # Common parameter to increase upload size limit in conjuction with dedicated php-fpm file
-  #client_max_body_size 50M;
-
-  try_files $uri $uri/ index.php;
-  location ~ [^/]\.php(/|$) {
-    fastcgi_split_path_info ^(.+?\.php)(/.*)$;
-    fastcgi_pass unix:/var/run/php5-fpm.sock;
-    
-    # Filename to be changed if dedicated php-fpm process is required
-    # This is to be used INSTEAD of line above
-    # Don't forget to adjust scripts install/upgrade/remove/backup accordingly
-    #
-    #fastcgi_pass unix:/var/run/php5-fpm-YNH_WWW_APP.sock;
-
-    fastcgi_index index.php;
-    include fastcgi_params;
-    fastcgi_param REMOTE_USER $remote_user;
-    fastcgi_param PATH_INFO $fastcgi_path_info;
-    fastcgi_param SCRIPT_FILENAME $request_filename;
-  }
-  # PHP configuration end
-
-  # Include SSOWAT user panel.
-  include conf.d/yunohost_panel.conf.inc;
+	include conf.d/yunohost_panel.conf.inc;
+	proxy_set_header Accept-Encoding "";
 }

--- a/manifest.json
+++ b/manifest.json
@@ -14,7 +14,7 @@
         "url": "http://example.com"
     },
     "requirements": {
-        "yunohost": ">> 2.4.0"
+        "yunohost": ">> 2.6.0"
     },
     "multi_instance": true,
     "services": [

--- a/scripts/install
+++ b/scripts/install
@@ -29,7 +29,7 @@ ynh_app_setting_set "$app" is_public "$is_public"
 
 mailadmin=$(ynh_user_get_info $admin mail)
 portNginx=$(ynh_find_port 8080)
-portUnicorn=$(ynh_find_port 8080)
+portUnicorn=$(ynh_find_port 9080)
 rdmPass=$(ynh_string_random 30)
 
 # Check domain/path availability

--- a/scripts/install
+++ b/scripts/install
@@ -28,6 +28,8 @@ source /usr/share/yunohost/helpers
 ynh_app_setting_set "$app" is_public "$is_public"
 
 mailadmin=$(ynh_user_get_info $admin mail)
+port=$(ynh_find_port 8080)
+rdmPass=$(ynh_string_random 30)
 
 # Check domain/path availability
 sudo yunohost app checkurl "${domain}${path_url}" -a "$app" \
@@ -52,10 +54,8 @@ sed -i "s@PORT@$port@" ../conf/gitlab.rb
 sudo cp -f ../conf/gitlab.rb /etc/gitlab/gitlab.rb
 sudo gitlab-ctl reconfigure
 
-echo $admin
-echo $mailadmin
 
-echo "newuser = User.new({ \"email\"=>'$mailadmin', \"username\"=>'$admin', \"name\"=>'$admin', \"password\"=>'12345678'})
+echo "newuser = User.new({ \"email\"=>'$mailadmin', \"username\"=>'$admin', \"name\"=>'$admin', \"password\"=>'$rdmPass'})
 newuser.admin = true
 newuser.confirmed_at = Time.now
 newuser.confirmation_token = nil

--- a/scripts/install
+++ b/scripts/install
@@ -74,6 +74,7 @@ sudo gitlab-ctl reconfigure
 # Modify Nginx configuration file and copy it to Nginx conf directory
 nginx_conf=../conf/nginx.conf
 sed -i "s@YNH_WWW_PATH@$path_url@g" $nginx_conf
+sed -i "s@PORT@$port@g" $nginx_conf
 # sed -i "s@YNH_WWW_ALIAS@$src_path/@g" $nginx_conf
 # If a dedicated php-fpm process is used:
 # Don't forget to modify ../conf/nginx.conf accordingly or your app will not work!
@@ -88,4 +89,6 @@ if [[ $is_public -eq 1 ]]; then
 fi
 
 # Reload services
+sudo yunohost app ssowatconf
 sudo service nginx reload
+sudo gitlab-ctl restart

--- a/scripts/install
+++ b/scripts/install
@@ -28,7 +28,8 @@ source /usr/share/yunohost/helpers
 ynh_app_setting_set "$app" is_public "$is_public"
 
 mailadmin=$(ynh_user_get_info $admin mail)
-port=$(ynh_find_port 8080)
+portNginx=$(ynh_find_port 8080)
+portUnicorn=$(ynh_find_port 8080)
 rdmPass=$(ynh_string_random 30)
 
 # Check domain/path availability
@@ -49,7 +50,8 @@ sudo apt-get install -yy gitlab-ce
 # Gitlab configuration
 
 sed -i "s@GENERATED_EXTERNAL_URL@https://$domain@" ../conf/gitlab.rb
-sed -i "s@PORT@$port@" ../conf/gitlab.rb
+sed -i "s@PORTNGINX@$portNginx@" ../conf/gitlab.rb
+sed -i "s@PORTUNICORN@$portUnicorn@" ../conf/gitlab.rb
 
 sudo cp -f ../conf/gitlab.rb /etc/gitlab/gitlab.rb
 sudo gitlab-ctl reconfigure

--- a/scripts/install
+++ b/scripts/install
@@ -74,7 +74,7 @@ sudo gitlab-ctl reconfigure
 # Modify Nginx configuration file and copy it to Nginx conf directory
 nginx_conf=../conf/nginx.conf
 sed -i "s@YNH_WWW_PATH@$path_url@g" $nginx_conf
-sed -i "s@YNH_WWW_ALIAS@$src_path/@g" $nginx_conf
+# sed -i "s@YNH_WWW_ALIAS@$src_path/@g" $nginx_conf
 # If a dedicated php-fpm process is used:
 # Don't forget to modify ../conf/nginx.conf accordingly or your app will not work!
 # sed -i "s@YNH_WWW_APP@$app@g" $nginx_conf

--- a/scripts/install
+++ b/scripts/install
@@ -76,7 +76,7 @@ sudo gitlab-ctl reconfigure
 # Modify Nginx configuration file and copy it to Nginx conf directory
 nginx_conf=../conf/nginx.conf
 sed -i "s@YNH_WWW_PATH@$path_url@g" $nginx_conf
-sed -i "s@PORT@$port@g" $nginx_conf
+sed -i "s@PORT@$portNginx@g" $nginx_conf
 # sed -i "s@YNH_WWW_ALIAS@$src_path/@g" $nginx_conf
 # If a dedicated php-fpm process is used:
 # Don't forget to modify ../conf/nginx.conf accordingly or your app will not work!


### PR DESCRIPTION
**This is my first contribution. Be nice with me.**


I worked a time ago to make a gitlab yunohost app. at this time, I didn't success to link with LDAP.

Yesterday, i make a new try. 
It's probably not perfect, but it works !

After that, I fork this repo, and add my code. I make some change to make it work properly.


During install, you must choose an admin user, who will be assign to gitlab.

- [x] link LDAP
- [x] make selected admin as LDAP admin
- [x] make integration with this repo.

I have change some line/file to make it work/install correctly.
