### PR TITLE
Fix waiting for gitlab and path_url

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
     "name": "Gitlab",
     "id": "gitlab",
     "packaging_format": 1,
-    "version": "11.10.4~ynh4",
+    "version": "11.10.4~ynh5",
     "description": {
         "en": "GitLab is a Git-repository manager.",
         "fr": "GitLab est un gestionnaire de dépôts Git."

--- a/scripts/install
+++ b/scripts/install
@@ -78,7 +78,7 @@ ynh_webpath_register --app=$app --domain=$domain --path_url=$path_url
 ynh_script_progression --message="Storing installation settings..." --weight=2
 
 ynh_app_setting_set --app=$app --key=admin --value=$admin
-ynh_app_setting_set --app=$app --key=path_url --value=$path_url
+ynh_app_setting_set --app=$app --key=path --value=$path_url
 ynh_app_setting_set --app=$app --key=is_public --value=$is_public
 ynh_app_setting_set --app=$app --key=use_web_account --value=$use_web_account
 ynh_app_setting_set --app=$app --key=final_path --value=$final_path

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -296,10 +296,14 @@ fi
 #=================================================
 # WAITING GITLAB
 #=================================================
-ynh_script_progression --message="Waiting for gitlab..." --weight=15
 
-# Action status to just wait the service
-ynh_systemd_action --action=status --service_name="gitlab-runsvdir" --log_path="/var/log/$app/unicorn/current" --line_match="adopted" --timeout=3600
+if [ "$upgrade_type" == "UPGRADE_APP" ]
+then
+	ynh_script_progression --message="Waiting for gitlab..." --weight=15
+
+	# Action status to just wait the service
+	ynh_systemd_action --action=status --service_name="gitlab-runsvdir" --log_path="/var/log/$app/unicorn/current" --line_match="adopted" --timeout=3600
+fi
 
 #=================================================
 # RELOAD NGINX

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -104,6 +104,7 @@ fi
 # If client_max_body_size doesn't exist, create it
 if [ -z "$client_max_body_size" ]; then
 	client_max_body_size="250m"
+	ynh_app_setting_set --app=$app --key=client_max_body_size --value=$client_max_body_size
 fi
 
 # If overwrite_nginx doesn't exist, create it

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -126,7 +126,7 @@ fi
 if [ -z "$path_url" ]; then
 	path_url=$(grep "location" "/etc/nginx/conf.d/${domain}.d/gitlab.conf" | cut -d' ' -f2)
 	path_url=$(ynh_normalize_url_path $path_url)
-	ynh_app_setting_set --app=$app --key=path_url --value=path_url
+	ynh_app_setting_set --app=$app --key=path --value=path_url
 fi
 
 # If port doesn't exist, retrieve it

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -20,7 +20,7 @@ app=$YNH_APP_INSTANCE_NAME
 
 # Retrieve app settings
 domain=$(ynh_app_setting_get --app="$app" --key=domain)
-path_url=$(ynh_app_setting_get --app="$app" --key=path_url)
+path_url=$(ynh_app_setting_get --app="$app" --key=path)
 admin=$(ynh_app_setting_get --app="$app" --key=admin)
 is_public=$(ynh_app_setting_get --app="$app" --key=is_public)
 final_path=$(ynh_app_setting_get --app=$app --key=final_path)


### PR DESCRIPTION
## Problem
- Wait for gitlab even if the application has not been updated

## Solution
- Don't wait

## PR Status
- [ ] Code finished.
- [ ] Tested with Package_check.
- [ ] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [ ] Can be reviewed and tested.

## Validation
---
- [ ] **Code review**
- [ ] **Approval (LGTM)**  
*Code review and approval have to be from a member of @YunoHost/apps group*
- **CI succeeded** : 
[![Build Status](https://ci-apps-hq.yunohost.org/jenkins/job/gitlab_ynh%20PR-NUM-/badge/icon)](https://ci-apps-hq.yunohost.org/jenkins/job/gitlab_ynh%20PR-NUM-/)  
*Please replace '-NUM-' in this link by the PR number.*  
When the PR is marked as ready to merge, you have to wait for 3 days before really merging it.
