### PR TITLE
skip-auto-backup

### DIFF
--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -278,6 +278,9 @@ if [ "$upgrade_type" == "UPGRADE_APP" ]
 then
 	ynh_script_progression --message="Setting up source files..." --weight=200
 
+	# To avoid the automatic backup, already performed by YunoHost: https://docs.gitlab.com/omnibus/update/#updating-methods
+	touch $config_path/skip-auto-backup
+
 	current_version=$(grep gitlab-ce /opt/gitlab/version-manifest.txt | cut -d' ' -f2)
 
 	# Load the last available version


### PR DESCRIPTION
## Problem
- *Gitlab have an automatic backup during the upgrade, useless for YunoHost*

## Solution
- *Disabled it*

## PR Status
- [ ] Code finished.
- [ ] Tested with Package_check.
- [ ] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [ ] Can be reviewed and tested.

## Validation
---
- [ ] **Code review** : 
- [ ] **Approval (LGTM)** :  
*Code review and approval have to be from a member of @YunoHost-Apps/apps-group*
- **CI succeeded** : 
[![Build Status](https://ci-apps-hq.yunohost.org/jenkins/job/gitlab_ynh%20PR-NUM-/badge/icon)](https://ci-apps-hq.yunohost.org/jenkins/job/gitlab_ynh%20PR-NUM-/)  
*Please replace '-NUM-' in this link by the PR number.*  
When the PR is marked as ready to merge, you have to wait for 3 days before really merging it.
