### PR TITLE
13.4.0, drop stretch support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ If you don't have YunoHost, please see [here](https://yunohost.org/#/install) to
 
 GitLab is a web-based Git-repository manager providing wiki, issue-tracking and CI/CD pipeline features, using an open-source license, developed by GitLab Inc.
 
-**Shipped version:** 13.3.4
+**Shipped version:** 13.4.0
 
 ## Screenshots
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -12,7 +12,7 @@ Si vous n'avez pas YunoHost, regardez [ici](https://yunohost.org/#/install) pour
 
 GitLab est un gestionnaire Web de dépôt Git fournissant des fonctionnalités de wiki, de rapports de bugs et de pipeline CI/CD. GitLab est une application open source développée par GitLab Inc.
 
-**Version incluse :** 13.3.4
+**Version incluse :** 13.4.0
 
 ## Captures d'écran
 

--- a/conf/arm.src.default
+++ b/conf/arm.src.default
@@ -1,4 +1,4 @@
-SOURCE_URL=https://packages.gitlab.com/gitlab/raspberry-pi2/packages/raspbian/__DEBIAN_VERSION__/gitlab-ce___VERSION__-ce.0_armhf.deb/download.deb
+SOURCE_URL=https://packages.gitlab.com/gitlab/raspberry-pi2/packages/raspbian/buster/gitlab-ce___VERSION__-ce.0_armhf.deb/download.deb
 SOURCE_SUM=__SHA256_SUM__
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FILENAME=__SOURCE_FILENAME__

--- a/conf/gitlab.rb
+++ b/conf/gitlab.rb
@@ -161,6 +161,8 @@ external_url '__GENERATED_EXTERNAL_URL__'
 # gitlab_rails['pages_domain_ssl_renewal_cron_worker'] = "*/10 * * * *"
 # gitlab_rails['pages_domain_removal_cron_worker'] = "47 0 * * *"
 # gitlab_rails['schedule_migrate_external_diffs_worker_cron'] = "15 * * * *"
+# gitlab_rails['ci_platform_metrics_update_cron_worker'] = '47 9 * * *'
+# gitlab_rails['analytics_instance_statistics_count_job_trigger_worker_cron'] = "50 23 */1 * *"
 
 ### Webhook Settings
 ###! Number of seconds to wait for HTTP response after sending webhook HTTP POST
@@ -491,6 +493,7 @@ EOS
 # gitlab_rails['omniauth_block_auto_created_users'] = true
 # gitlab_rails['omniauth_auto_link_ldap_user'] = false
 # gitlab_rails['omniauth_auto_link_saml_user'] = false
+# gitlab_rails['omniauth_auto_link_user'] = ['saml']
 # gitlab_rails['omniauth_external_providers'] = ['twitter', 'google_oauth2']
 # gitlab_rails['omniauth_allow_bypass_two_factor'] = ['google_oauth2']
 # gitlab_rails['omniauth_providers'] = [
@@ -644,6 +647,7 @@ gitlab_rails['gitlab_shell_ssh_port'] = __SSH_PORT__
 # gitlab_rails['db_sslkey'] = nil
 # gitlab_rails['db_prepared_statements'] = false
 # gitlab_rails['db_statements_limit'] = 1000
+# gitlab_rails['db_connect_timeout'] = nil
 
 
 ### GitLab Redis settings
@@ -961,6 +965,7 @@ puma['port'] = __PUMA_PORT__
 # sidekiq['negate'] = false
 
 # sidekiq['metrics_enabled'] = true
+# sidekiq['exporter_log_enabled'] = false
 # sidekiq['listen_address'] = "localhost"
 sidekiq['listen_port'] = __SIDEKIQ_PORT__
 
@@ -1341,7 +1346,7 @@ nginx['listen_https'] = false
 # nginx['cache_max_size'] = '5000m'
 # nginx['server_names_hash_bucket_size'] = 64
 ##! These paths have proxy_request_buffering disabled
-# nginx['request_buffering_off_path_regex'] = "\.git/git-receive-pack$|\.git/info/refs?service=git-receive-pack$|\.git/gitlab-lfs/objects|\.git/info/lfs/objects/batch$"
+# nginx['request_buffering_off_path_regex'] = "/api/v\\d/jobs/\\d+/artifacts$|\\.git/git-receive-pack$|\\.git/gitlab-lfs/objects|\\.git/info/lfs/objects/batch$"
 
 ### Nginx status
 # nginx['status'] = {
@@ -1351,7 +1356,6 @@ nginx['listen_https'] = false
 #  "port" => 9999,
 #  "vts_enable" => true,
 #  "options" => {
-#    "stub_status" => "on", # Turn on stats
 #    "server_tokens" => "off", # Don't show the version of NGINX
 #    "access_log" => "off", # Disable logs for stats
 #    "allow" => "127.0.0.1", # Only allow access from localhost
@@ -1672,6 +1676,7 @@ nginx['listen_https'] = false
 # prometheus['rules_files'] = ['/var/opt/gitlab/prometheus/rules/*.rules']
 # prometheus['scrape_interval'] = 15
 # prometheus['scrape_timeout'] = 15
+# prometheus['external_labels'] = { }
 # prometheus['env_directory'] = '/opt/gitlab/etc/prometheus/env'
 # prometheus['env'] = {
 #   'SSL_CERT_DIR' => "/opt/gitlab/embedded/ssl/certs/"
@@ -1742,8 +1747,8 @@ nginx['listen_https'] = false
 # alertmanager['log_directory'] = '/var/log/gitlab/alertmanager'
 # alertmanager['admin_email'] = 'admin@example.com'
 # alertmanager['flags'] = {
-#   'web.listen-address' => "localhost:9093"
-#   'storage.path' => "/var/opt/gitlab/alertmanager/data"
+#   'web.listen-address' => "localhost:9093",
+#   'storage.path' => "/var/opt/gitlab/alertmanager/data",
 #   'config.file' => "/var/opt/gitlab/alertmanager/alertmanager.yml"
 # }
 # alertmanager['env_directory'] = '/opt/gitlab/etc/alertmanager/env'
@@ -2026,6 +2031,8 @@ nginx['listen_https'] = false
 # praefect['database_sslcert'] = '/path/to/client-cert'
 # praefect['database_sslkey'] = '/path/to/client-key'
 # praefect['database_sslrootcert'] = '/path/to/rootcert'
+# praefect['reconciliation_scheduling_interval'] = '5m'
+# praefect['reconciliation_histogram_buckets'] = '[0.001, 0.005, 0.025, 0.1, 0.5, 1.0, 10.0]'
 
 ################################################################################
 # Storage check

--- a/conf/x86-64.src.default
+++ b/conf/x86-64.src.default
@@ -1,4 +1,4 @@
-SOURCE_URL=https://packages.gitlab.com/gitlab/gitlab-ce/packages/debian/__DEBIAN_VERSION__/gitlab-ce___VERSION__-ce.0_amd64.deb/download.deb
+SOURCE_URL=https://packages.gitlab.com/gitlab/gitlab-ce/packages/debian/buster/gitlab-ce___VERSION__-ce.0_amd64.deb/download.deb
 SOURCE_SUM=__SHA256_SUM__
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FILENAME=__SOURCE_FILENAME__

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
     "name": "Gitlab",
     "id": "gitlab",
     "packaging_format": 1,
-    "version": "13.3.4~ynh1",
+    "version": "13.4.0~ynh1",
     "description": {
         "en": "Git-repository manager.",
         "fr": "Gestionnaire de dépôts Git."
@@ -14,7 +14,7 @@
         "email": "pierre@kayou.io"
     },
     "requirements": {
-        "yunohost": ">= 3.8.1"
+        "yunohost": ">= 4.0.8"
     },
     "multi_instance": false,
     "services": [

--- a/scripts/install
+++ b/scripts/install
@@ -183,7 +183,6 @@ source ./upgrade.d/upgrade.last.sh
 cp ../conf/$architecture.src.default ../conf/$architecture.src
 ynh_replace_string --match_string="__VERSION__" --replace_string="$gitlab_version" --target_file="../conf/$architecture.src"
 ynh_replace_string --match_string="__SOURCE_FILENAME__" --replace_string="$gitlab_filename" --target_file="../conf/$architecture.src"
-ynh_replace_string --match_string="__DEBIAN_VERSION__" --replace_string="$gitlab_debian_version" --target_file="../conf/$architecture.src"
 ynh_replace_string --match_string="__SHA256_SUM__" --replace_string="$gitlab_source_sha256" --target_file="../conf/$architecture.src"
 
 tempdir="$(mktemp -d)"

--- a/scripts/restore
+++ b/scripts/restore
@@ -103,7 +103,6 @@ mkdir -p ../conf/
 cp ../settings/conf/$architecture.src.default ../conf/$architecture.src
 ynh_replace_string --match_string="__VERSION__" --replace_string="$gitlab_version" --target_file="../conf/$architecture.src"
 ynh_replace_string --match_string="__SOURCE_FILENAME__" --replace_string="$gitlab_filename" --target_file="../conf/$architecture.src"
-ynh_replace_string --match_string="__DEBIAN_VERSION__" --replace_string="$gitlab_debian_version" --target_file="../conf/$architecture.src"
 ynh_replace_string --match_string="__SHA256_SUM__" --replace_string="$gitlab_source_sha256" --target_file="../conf/$architecture.src"
 
 tempdir="$(mktemp -d)"

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -269,7 +269,6 @@ then
 		cp ../conf/$architecture.src.default ../conf/$architecture.src
 		ynh_replace_string --match_string="__VERSION__" --replace_string="$gitlab_version" --target_file="../conf/$architecture.src"
 		ynh_replace_string --match_string="__SOURCE_FILENAME__" --replace_string="$gitlab_filename" --target_file="../conf/$architecture.src"
-		ynh_replace_string --match_string="__DEBIAN_VERSION__" --replace_string="$gitlab_debian_version" --target_file="../conf/$architecture.src"
 		ynh_replace_string --match_string="__SHA256_SUM__" --replace_string="$gitlab_source_sha256" --target_file="../conf/$architecture.src"
 
 		tempdir="$(mktemp -d)"

--- a/scripts/upgrade.d/upgrade.last.sh
+++ b/scripts/upgrade.d/upgrade.last.sh
@@ -1,35 +1,19 @@
 #!/bin/bash
 
-gitlab_version="13.3.4"
+gitlab_version="13.4.0"
 
 # sha256sum found here: https://packages.gitlab.com/gitlab
 
-gitlab_debian_version="$(lsb_release -sc)"
+gitlab_x86_64_buster_source_sha256="029f60fc028033493e2f1027802ad5cd978e09707107f44abe5bd15170bd6a92"
 
-gitlab_x86_64_buster_source_sha256="bf0d2924f10765d08724ea78d8f5ceff4dc4d25d14a5f282aa27d62640f21d23"
-
-gitlab_arm_buster_source_sha256="ee9b8ac7816dbedf73e319fea4c14ac1c743f06bad4a2597e5753f81789337d1"
-
-gitlab_x86_64_stretch_source_sha256="bc6800fdd5f91cb18c712ea15e93887141b81658566c780231aa63051cc9fcf0"
-
-gitlab_arm_stretch_source_sha256="362ab23dfc97814027c428e23900337223d3ae4c1c9220ad35b7ffd341f666cc"
+gitlab_arm_buster_source_sha256="592d8346af106d7c274189872a8ee46c7225c9f6b8a731990715264e9edb776a"
 
 architecture=$(ynh_app_setting_get --app="$app" --key=architecture)
 
 if [ "$architecture" = "x86-64" ]; then
-	if [ "$gitlab_debian_version" = "buster" ]
-	then
-		gitlab_source_sha256=$gitlab_x86_64_buster_source_sha256
-	else
-		gitlab_source_sha256=$gitlab_x86_64_stretch_source_sha256
-	fi
+	gitlab_source_sha256=$gitlab_x86_64_buster_source_sha256
 elif [ "$architecture" = "arm" ]; then
-	if [ "$gitlab_debian_version" = "buster" ]
-	then
-		gitlab_source_sha256=$gitlab_arm_buster_source_sha256
-	else
-		gitlab_source_sha256=$gitlab_arm_stretch_source_sha256
-	fi
+	gitlab_source_sha256=$gitlab_arm_buster_source_sha256
 fi
 
 gitlab_filename="gitlab-ce-${gitlab_version}.deb"

--- a/upgrade-versions.sh
+++ b/upgrade-versions.sh
@@ -15,30 +15,24 @@ gitlab_directory="$( cd "$( dirname "$current_dir/$1" )/../../" >/dev/null 2>&1 
 sed -i -e "s/gitlab_version=\"[^0-9.]*[0-9.]*[0-9.]\"/gitlab_version=\"$version\"/" $gitlab_directory/scripts/upgrade.d/$file
 
 # x86_64
-for debian_version in "stretch" "buster"
-do
-    url=https://packages.gitlab.com/gitlab/gitlab-ce/packages/debian/$debian_version/gitlab-ce_$version-ce.0_amd64.deb
+url=https://packages.gitlab.com/gitlab/gitlab-ce/packages/debian/buster/gitlab-ce_$version-ce.0_amd64.deb
 
-    new_sha256=$(curl -s $url | sed -n '/SHA256$/,/<\/tr>$/{ /SHA256$/d; /<\/tr>$/d; p; }' | cut -d$'\n' -f3 | xargs)
+new_sha256=$(curl -s $url | sed -n '/SHA256$/,/<\/tr>$/{ /SHA256$/d; /<\/tr>$/d; p; }' | cut -d$'\n' -f3 | xargs)
 
-    echo url: $url
-    echo sha256: $new_sha256
+echo url: $url
+echo sha256: $new_sha256
 
-    sed -i -e "s/gitlab_x86_64_${debian_version}_source_sha256=\".*\"/gitlab_x86_64_${debian_version}_source_sha256=\"$new_sha256\"/" $gitlab_directory/scripts/upgrade.d/$file
-done
+sed -i -e "s/gitlab_x86_64_buster_source_sha256=\".*\"/gitlab_x86_64_buster_source_sha256=\"$new_sha256\"/" $gitlab_directory/scripts/upgrade.d/$file
 
 # arm
-for debian_version in "stretch" "buster"
-do
-    url=https://packages.gitlab.com/gitlab/raspberry-pi2/packages/raspbian/$debian_version/gitlab-ce_$version-ce.0_armhf.deb
+url=https://packages.gitlab.com/gitlab/raspberry-pi2/packages/raspbian/buster/gitlab-ce_$version-ce.0_armhf.deb
 
-    new_sha256=$(curl -s $url | sed -n '/SHA256$/,/<\/tr>$/{ /SHA256$/d; /<\/tr>$/d; p; }' | cut -d$'\n' -f3 | xargs)
+new_sha256=$(curl -s $url | sed -n '/SHA256$/,/<\/tr>$/{ /SHA256$/d; /<\/tr>$/d; p; }' | cut -d$'\n' -f3 | xargs)
 
-    echo url: $url
-    echo sha256: $new_sha256
+echo url: $url
+echo sha256: $new_sha256
 
-    sed -i -e "s/gitlab_arm_${debian_version}_source_sha256=\".*\"/gitlab_arm_${debian_version}_source_sha256=\"$new_sha256\"/" $gitlab_directory/scripts/upgrade.d/$file
-done
+sed -i -e "s/gitlab_arm_buster_source_sha256=\".*\"/gitlab_arm_buster_source_sha256=\"$new_sha256\"/" $gitlab_directory/scripts/upgrade.d/$file
 
 if [[ "$(basename $file)" == upgrade.last.sh ]]; then
     # Update manifest


### PR DESCRIPTION
## Solution
- *[13.4.0](https://about.gitlab.com/releases/2020/09/22/gitlab-13-4-released/)*

## PR Status
- [ ] Code finished.
- [ ] Tested with Package_check.
- [ ] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [ ] Can be reviewed and tested.

## Validation
---
- [ ] **Code review** : 
- [ ] **Approval (LGTM)** :  
*Code review and approval have to be from a member of @YunoHost-Apps/apps-group*
- **CI succeeded** : 
[![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/gitlab_ynh%20PR123%20(Kay0u)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/gitlab_ynh%20PR123%20(Kay0u)/) 
When the PR is marked as ready to merge, you have to wait for 3 days before really merging it.
