### PR TITLE
[fix] Don't display all db migration log

### DIFF
--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -308,7 +308,7 @@ then
 				chown root:root "$config_path/gitlab-persistent.rb"
 				chmod 640 "$config_path/gitlab-persistent.rb"
 
-				gitlab-ctl reconfigure
+				gitlab-ctl reconfigure > /dev/null
 			fi
 		fi
 	done
@@ -325,7 +325,7 @@ touch "$config_path/gitlab-persistent.rb"
 chown root:root "$config_path/gitlab-persistent.rb"
 chmod 640 "$config_path/gitlab-persistent.rb"
 
-gitlab-ctl reconfigure
+gitlab-ctl reconfigure > /dev/null
 
 # Allow ssh for git
 usermod -a -G "ssh.app" "git"

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -308,7 +308,10 @@ then
 				chown root:root "$config_path/gitlab-persistent.rb"
 				chmod 640 "$config_path/gitlab-persistent.rb"
 
-				gitlab-ctl reconfigure > /dev/null
+				# During large migrations, the logs are too big to be sent to paste.yunohost.org
+				# Send the reconfigure logs in a file, and if the process succeeds, just delete it.
+				gitlab-ctl reconfigure > "/tmp/gitlab_upgrade_$current_version.log"
+				ynh_secure_remove --file="/tmp/gitlab_upgrade_$current_version.log"
 			fi
 		fi
 	done
@@ -325,7 +328,7 @@ touch "$config_path/gitlab-persistent.rb"
 chown root:root "$config_path/gitlab-persistent.rb"
 chmod 640 "$config_path/gitlab-persistent.rb"
 
-gitlab-ctl reconfigure > /dev/null
+gitlab-ctl reconfigure
 
 # Allow ssh for git
 usermod -a -G "ssh.app" "git"


### PR DESCRIPTION
## Problem
Gitlab internal migrations logs should not be displayed like this.
https://forum.yunohost.org/t/failed-to-upgrade-gitlab/17536/7?u=ljf

## Solution
output in dev null

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
