### PR TITLE
Update restore: i guess you meant to check "system users", not yunohost user

### DIFF
--- a/scripts/restore
+++ b/scripts/restore
@@ -87,7 +87,7 @@ gitlab-ctl stop sidekiq
 ynh_exec_warn_less gitlab-backup restore force=yes BACKUP=$last_backup
 
 # https://docs.gitlab.com/ce/raketasks/backup_restore.html#container-registry-push-failures-after-restoring-from-a-backup
-if ynh_user_exists --username="registry" && [ -d "/var/opt/gitlab/gitlab-rails/shared/registry/docker" ]; then
+if ynh_system_user_exists --username="registry" && [ -d "/var/opt/gitlab/gitlab-rails/shared/registry/docker" ]; then
 	chown -R registry:registry /var/opt/gitlab/gitlab-rails/shared/registry/docker
 fi
 


### PR DESCRIPTION
Funfact, this is the only app using this helper .. which as the name makes it obvious (no), checks the existence of a *yunohost* user, not a system user. But I very much doubt that there'll be a "registry" yunohost user, you probably meant the system user ?