### PR TITLE
List a single upstream code URL

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -14,7 +14,7 @@ license = "MIT"
 website = "https://gitlab.com"
 demo = "https://gitlab.com/explore"
 admindoc = "https://docs.gitlab.com/"
-code = "https://gitlab.com/gitlab-org/omnibus-gitlab - https://gitlab.com/gitlab-org/gitlab"
+code = "https://gitlab.com/gitlab-org/gitlab"
 cpe = "cpe:2.3:a:gitlab:gitlab"
 
 [integration]


### PR DESCRIPTION
The YunoHost app catalogue treats this field as a single URL. Thus, the link in the catalogue is broken.

## Problem

The YunoHost app catalogue treats this field as a single URL. Thus, the link in the catalogue is broken.

## Solution

Put a single URL in the field. Alternatively, the omnibus repo could be it, I don't mind either.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- na The fix/enhancement were manually tested (if applicable)

## Notes

Doing this to fix my scraper of update histories :D